### PR TITLE
Add menu items for settings editing

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,35 @@
+[
+    {
+        "caption": "Preferences",
+        "mnemonic": "n",
+        "id": "preferences",
+        "children":
+        [
+            {
+                "caption": "Package Settings",
+                "mnemonic": "P",
+                "id": "package-settings",
+                "children":
+                [
+                    {
+                        "caption": "RustAutoComplete",
+                        "children":
+                        [
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/RustAutoComplete/Preferences.sublime-settings"},
+                                "caption": "Settings – Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/User/RustAutoComplete.sublime-settings"},
+                                "caption": "Settings – User"
+                            },
+                            { "caption": "-" }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ https://github.com/phildawes/racer
 3. Install the package through package control (or clone from git if you prefer):
 https://sublime.wbond.net/packages/RustAutoComplete
 4. Configure the plugin to be able to find the racer executable and
-Rust source code. Create a file called RustAutoComplete.sublime-settings
-in your Packages/User directory, using below as a template:
+Rust source code. Open menu
+`Preferences -> Package settings -> RustAutoComplete -> Settings - User`
+and edit the settings file using below as a template:
 
 ```
 {

--- a/messages/install.txt
+++ b/messages/install.txt
@@ -28,8 +28,12 @@ Requirements
     https://github.com/phildawes/racer
 
 3) Configure the plugin to be able to find the racer executable and
-    Rust source code. Create a file called RustAutoComplete.sublime-settings
-    in your Packages/User directory, using below as a template:
+    Rust source code. Rust source code. Open menu
+
+    Preferences -> Package settings -> RustAutoComplete -> Settings - User
+
+    and edit the settings file using below as a template:
+
 
     // Copy this and place into your Packages/User directory.
     {


### PR DESCRIPTION
On the first call `Settings - User` will create settings file automatically
![rustautocompletemenu](https://cloud.githubusercontent.com/assets/1297574/4982917/6d07d474-6916-11e4-93fa-37fc3b39cc7e.png)
