### PR TITLE
Hack GotoDefinition to work on Windows

### DIFF
--- a/RustAutoComplete.py
+++ b/RustAutoComplete.py
@@ -1,6 +1,8 @@
 import os
 import sublime
 import sublime_plugin
+import platform
+import re
 import subprocess
 from subprocess import Popen, PIPE
 
@@ -150,5 +152,8 @@ class RustGotoDefinitionCommand(sublime_plugin.TextCommand):
 
         if len(results) == 1:
             result = results[0]
-            encoded_path = "{0}:{1}:{2}".format(result.path, result.row, result.column)
+            path = result.path
+            # On Windows the racer will return the paths without the drive letter and we need the letter for the open_file to work.
+            if platform.system() == 'Windows' and not re.compile('^\w\:').match(path): path = 'c:' + path
+            encoded_path = "{0}:{1}:{2}".format(path, result.row, result.column)
             self.view.window().open_file(encoded_path, sublime.ENCODED_POSITION)


### PR DESCRIPTION
A proper fix would be to return the drive letter from the racer I guess, but this fix has some merit meanwhile.
