### PR TITLE
Check if racer executable exist before run racer

### DIFF
--- a/RustAutoComplete.py
+++ b/RustAutoComplete.py
@@ -4,6 +4,7 @@ import sublime_plugin
 import re
 import subprocess
 import tempfile
+import shutil
 from subprocess import Popen, PIPE
 
 
@@ -101,6 +102,11 @@ def determine_save_dir(view):
 
 
 def run_racer(view, cmd_list):
+    # Return if can't find racer
+    if shutil.which(settings.racer_bin) is None:
+        print("Unable to find racer executable (check settings)")
+        return []
+
     # Retrieve the entire buffer
     region = sublime.Region(0, view.size())
     content = view.substr(region)
@@ -172,10 +178,8 @@ class RustAutocomplete(sublime_plugin.EventListener):
             row, col = view.rowcol(locations[0])
             row += 1
 
-            try:
-                raw_results = run_racer(view, ["complete-with-snippet", str(row), str(col)])
-            except FileNotFoundError:
-                print("Unable to find racer executable (check settings)")
+            raw_results = run_racer(view, ["complete-with-snippet", str(row), str(col)])
+            if raw_results == []:
                 return
 
             results = []


### PR DESCRIPTION
In the original version, if racer does not exist, the call to racer `Popen(cmd_list, stdout=PIPE, stderr=PIPE, env=env, startupinfo=startupinfo)` will raise a `FileNotFoundError` and get caught by upper caller `on_query_completions`.

The problem here is, once the error is raised, `run_racer` returns immediately and skipped `os.remove(temp_file_path)`, therefore the temporary file doesn't get deleted and piles up.

Screenshot: [tmp files can't get cleaned](https://i.imgur.com/Yo7QIHT.png)

By checking the existence of racer before any work begins, we can avoid the creation of temp files